### PR TITLE
Changed to use runtimePath from ECFI instead of moqui.runtime system …

### DIFF
--- a/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/ExecutionContextFactoryImpl.groovy
@@ -261,9 +261,10 @@ class ExecutionContextFactoryImpl implements ExecutionContextFactory {
     }
 
     protected MNode initBaseConfig(MNode runtimeConfXmlRoot) {
-        // always set the full moqui.runtime, moqui.conf system properties for use in various places
-        System.setProperty("moqui.runtime", runtimePath)
-        System.setProperty("moqui.conf", runtimeConfPath)
+        // don't set the moqui.runtime and moqui.conf system properties as before, causes conflict with multiple moqui instances in one JVM
+        // NOTE: moqui.runtime is set in MoquiStart and in MoquiContextListener (if there is an embedded runtime directory)
+        // System.setProperty("moqui.runtime", runtimePath)
+        // System.setProperty("moqui.conf", runtimeConfPath)
 
         logger.info("Initializing Moqui ExecutionContextFactoryImpl\n - runtime directory: ${this.runtimePath}\n - runtime config:    ${this.runtimeConfPath}")
 

--- a/framework/src/main/groovy/org/moqui/impl/context/WebFacadeImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/context/WebFacadeImpl.groovy
@@ -1298,9 +1298,9 @@ class WebFacadeImpl implements WebFacade {
         session.setAttribute("moqui.error.parameters", parms)
     }
 
-    static DiskFileItemFactory makeDiskFileItemFactory(ServletContext context) {
+    DiskFileItemFactory makeDiskFileItemFactory(ServletContext context) {
         // NOTE: consider keeping this factory somewhere to be more efficient, if it even makes a difference...
-        File repository = new File(System.getProperty("moqui.runtime") + "/tmp")
+        File repository = new File(eci.ecfi.runtimePath + "/tmp")
         if (!repository.exists()) repository.mkdir()
 
         DiskFileItemFactory factory = new DiskFileItemFactory(DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD, repository)

--- a/framework/src/main/groovy/org/moqui/impl/entity/EntityDatasourceFactoryImpl.groovy
+++ b/framework/src/main/groovy/org/moqui/impl/entity/EntityDatasourceFactoryImpl.groovy
@@ -74,7 +74,7 @@ class EntityDatasourceFactoryImpl implements EntityDatasourceFactory {
         } else if (datasourceNode.hasChild("inline-jdbc")) {
             // special thing for embedded derby, just set an system property; for derby.log, etc
             if (datasourceNode.attribute("database-conf-name") == "derby" && !System.getProperty("derby.system.home")) {
-                System.setProperty("derby.system.home", System.getProperty("moqui.runtime") + "/db/derby")
+                System.setProperty("derby.system.home", efi.ecfi.runtimePath + "/db/derby")
                 logger.info("Set property derby.system.home to [${System.getProperty("derby.system.home")}]")
             }
 


### PR DESCRIPTION
…property; don't set moqui.runtime and moqui.conf system properties in ECFI as causes issues with multiple moqui instances in one JVM; GitHub issue #78